### PR TITLE
Fix breaking config problem.

### DIFF
--- a/Parser/ServerCfgParser.cs
+++ b/Parser/ServerCfgParser.cs
@@ -398,7 +398,9 @@ namespace ServerManager.Utilities
                             {
                                 if(m.GetValue(servercfgData) != null)
                                 {
-                                    value = $"{m.GetValue(servercfgData)},";
+                                    value = m.GetValue(servercfgData)?.GetType() == typeof(Boolean)
+                                        ? $"{m.GetValue(servercfgData)?.ToString()?.ToLower()}"
+                                        : $"{m.GetValue(servercfgData)}";
                                 }
                             }
 


### PR DESCRIPTION
After
```csharp
var parser = new ServerCfgParser(@"D:\MappingAltVServer"); 
parser.ParseFile();
parser.SaveServerConfig();
```
My alt:V config is breaking. I have 
![image](https://user-images.githubusercontent.com/60060712/162608076-242f172c-2d2b-4b48-82de-d15266af6e20.png)
This is my solution for it.