### PR TITLE
Fix breaking config problem.

### DIFF
--- a/Parser/ServerCfgParser.cs
+++ b/Parser/ServerCfgParser.cs
@@ -398,7 +398,9 @@ namespace ServerManager.Utilities
                             {
                                 if(m.GetValue(servercfgData) != null)
                                 {
-                                    value = $"{m.GetValue(servercfgData)},";
+                                    value = m.GetValue(servercfgData)?.GetType() == typeof(Boolean)
+                                        ? $"{m.GetValue(servercfgData)?.ToString()?.ToLower()}"
+                                        : $"{m.GetValue(servercfgData)}";
                                 }
                             }
 


### PR DESCRIPTION
After
```csharp
var parser = new ServerCfgParser(@"D:\MappingAltVServer"); 
parser.ParseFile();
parser.SaveServerConfig();
```
My alt:V config is breaking.
This is my solution for it.